### PR TITLE
Specify version LGPL license in cabal file

### DIFF
--- a/HaXml.cabal
+++ b/HaXml.cabal
@@ -2,7 +2,7 @@ cabal-version:  >= 1.10
 name:           HaXml
 version:        1.25.7
 
-license:        LGPL
+license:        LGPL-2.1
 license-files:  COPYRIGHT, LICENCE-GPL, LICENCE-LGPL
 author:         Malcolm Wallace <Malcolm.Wallace@me.com>
 maintainer:     Jens Petersen <juhpetersen@gmail.com>


### PR DESCRIPTION
As far as I can tell from looking at the two license files HaXML is dual licensed under GPL-2.0 or LGPL-2.1

This is not reflected in the cabal `license` field, which only specifies LGPL without a version suffix.

This patch uses a spdx license specifier to accurately specify the license.  This is useful for tooling. For instance, `haskell.nix` throws a warning when parsing HaXML's license field as it doesn't recognise LGPL without a specified version.
