### PR TITLE
Correct logic-changing indentation in xquery

### DIFF
--- a/src/Text/XML/HaXml/Xtract/Parse.hs
+++ b/src/Text/XML/HaXml/Xtract/Parse.hs
@@ -253,8 +253,8 @@ xquery cxt q1 = oneOf
          do symbol "@"
             attr <- string
             return (D.iffind attr (local . C.literal) D.none `D.o` q1)
-         `onFail`
-         tquery ((q1 D./>):cxt)
+          `onFail`
+          tquery ((q1 D./>):cxt)
     , do symbol "//"
          tquery ((\q2-> liftLocal C.multi q2
                             `D.o` local C.children `D.o` q1):cxt)


### PR DESCRIPTION
This code was changed as part of some hlint-suggested fixes, but it was accidentally changed too much - the `onFail` was de-indented until it also wrapped the parent `do` block, which changed the behaviour of the code.

This changes it back by re-indenting the `onFail` so it only wraps the innermost `do`.

---

Frankly, I don't understand the code nearly well enough to know what this actually does. I found this issue because a recent upgrade of our `HaXml` copy broke some XML-parsing code we use, and I bisected until I located the change responsible.