### PR TITLE
fix pretty printer indentation

### DIFF
--- a/src/Text/XML/HaXml/Pretty.hs
+++ b/src/Text/XML/HaXml/Pretty.hs
@@ -103,8 +103,13 @@ element e@(Elem n as cs)
     | all isText cs    = text "<" <> qname n <+> fsep (map attribute as) <>
                          text ">" <> hcat (map content cs) <>
                          text "</" <> qname n <> text ">"
-    | otherwise        = let (d,c) = carryelem e empty
-                         in d <> c
+    | otherwise        = vcat [ text "<" <> qname n <> attributes as <> text ">"
+                              , nest 2 $ vcat (map content cs)
+                              , text "</" <> qname n <> text ">"
+                              ]
+
+attributes [] = empty
+attributes as@(_:_) = text " " <> fsep (map attribute as)
 
 isText :: Content t -> Bool
 isText (CString _ _ _) = True


### PR DESCRIPTION
In the `main` branch the indentation of both the bytestring and string pretty printers is wrong. Running this example file

```
:m +Text.XML.HaXml
:m +Text.XML.HaXml.Pretty

let elem = Elem (N "parent") [] [ CElem (Elem (N "child1") [] []) (), CElem (Elem (N "child2") [] []) ()]

element elem
```

we get

```
<parent
  ><child1
  /><child2/></parent>
```

but with this patch it is printed as

```
<parent>
  <child1/>
  <child2/>
</parent>
```