### PR TITLE
Bump base for GHC 9.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ghc: ['9.2', '9.0', '8.10', '8.8', '8.6', '8.4', '8.2', '8.0']
+        ghc: ['9.4', '9.2', '9.0', '8.10', '8.8', '8.6', '8.4', '8.2', '8.0']
     name: Haskell GHC ${{ matrix.ghc }}
     steps:
       - uses: actions/checkout@v2

--- a/HaXml.cabal
+++ b/HaXml.cabal
@@ -17,8 +17,9 @@ build-type:     Simple
 extra-doc-files: Changelog.md README
 
 tested-with:
-  GHC ==9.2.1
-   || ==9.0.1
+  GHC ==9.4.1
+   || ==9.2.4
+   || ==9.0.2
    || ==8.10.7
    || ==8.8.4
    || ==8.6.5
@@ -86,7 +87,7 @@ library
         Text.XML.HaXml.Schema.Schema
   hs-source-dirs: src
   build-depends:
-    base       >= 4.3.1.0  && < 4.17,
+    base       >= 4.3.1.0  && < 4.18,
     bytestring >= 0.9.1.10 && < 0.12,
     containers >= 0.4.0.0  && <0.7,
     filepath   >= 1.2.0.0  && <1.5,


### PR DESCRIPTION
Also update `tested-with` field to latest GHC versions.