### PR TITLE
Don't barf at text elements without inner html

### DIFF
--- a/src/Text/XML/HaXml/XmlContent/Parser.hs
+++ b/src/Text/XML/HaXml/XmlContent/Parser.hs
@@ -224,12 +224,10 @@ text = text' []
                  CRef (RefEntity s) _ -> text' (('&':s++";"):acc)
                  CMisc _ _            -> text' acc
                  CElem _ _         -> do { reparse [c] -- put it back!
-                                         ; if null acc then fail "empty string"
-                                           else return (concat (reverse acc))
+                                         ; return (concat (reverse acc))
                                          }
              }
-          `onFail` ( if null acc then fail "empty string"
-                     else return (concat (reverse acc)) )
+          `onFail` return (concat (reverse acc))
 
 
 -- | 'choice f p' means if parseContents succeeds, apply f to the result,


### PR DESCRIPTION
This allows parsing XML like `<foo></foo>` where foo is declared as text in the schema. Before this would throw an error as it doesn't contain text or children. After this MR it parses as empty text.

This is an upstreaming of this MR: https://github.com/tracsis/malcolm-wallace-universe/pull/1