### PR TITLE
Allow parsing empty strings, and fix space leak 

### DIFF
--- a/src/Text/XML/HaXml/Schema/Schema.hs
+++ b/src/Text/XML/HaXml/Schema/Schema.hs
@@ -70,7 +70,7 @@ class FwdDecl fd a | fd -> a
 -- | Given a TextParser for a SimpleType, make it into an XMLParser, i.e.
 --   consuming textual XML content as input rather than a String.
 parseSimpleType :: SimpleType t => XMLParser t
-parseSimpleType = do s <- text
+parseSimpleType = do s <- text `onFail` return ""
                      case runParser acceptingParser s of
                        (Left err, _) -> fail err
                        (Right v, "") -> return v


### PR DESCRIPTION
This MR reintroduces #10 and hopefully also fixes the space leak that the previous MR caused.

The previous MR made this function lazier than before, as we weren't scrutinising the `acc` parameter.
This MR reintroduces that strictness using a bang pattern.

My best guess to why there was a space leak is that this extra laziness caused a chain of thunks to be built up.

I don't have a reproduction of the issue though so it would be helpful if folks who've seen this in the wild could check to see if this solves their issue @juhp @byorgey

