### PR TITLE
HaXml 1.25.12 revsion 1: allow base-4.18; include GHC 9.6.1 alpha in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,8 +13,8 @@ jobs:
       matrix:
         ghc: ['9.4', '9.2', '9.0', '8.10', '8.8', '8.6', '8.4', '8.2', '8.0']
         include:
-          ghc: 9.6.0.20230111
-          ghcup_release_channel: "https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml"
+          - ghc: 9.6.0.20230111
+            ghcup_release_channel: "https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml"
     name: Haskell GHC ${{ matrix.ghc }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,12 +12,16 @@ jobs:
     strategy:
       matrix:
         ghc: ['9.4', '9.2', '9.0', '8.10', '8.8', '8.6', '8.4', '8.2', '8.0']
+        include:
+          ghc: 9.6.0.20230111
+          ghcup_release_channel: "https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml"
     name: Haskell GHC ${{ matrix.ghc }}
     steps:
       - uses: actions/checkout@v3
       - uses: haskell/actions/setup@v2
         with:
           ghc-version: ${{ matrix.ghc }}
+          ghcup-release-channel: ${{ matrix.ghcup_release_channel }}
       - uses: actions/cache@v3
         with:
           path: |

--- a/HaXml.cabal
+++ b/HaXml.cabal
@@ -1,6 +1,7 @@
 cabal-version:  1.18
 name:           HaXml
 version:        1.25.12
+x-revison:      1
 
 license:        LGPL-2.1
 license-files:  COPYRIGHT, LICENCE-GPL, LICENCE-LGPL
@@ -17,8 +18,9 @@ build-type:     Simple
 extra-doc-files: Changelog.md README
 
 tested-with:
-  GHC ==9.4.1
-   || ==9.2.4
+  GHC ==9.6.0
+   || ==9.4.4
+   || ==9.2.5
    || ==9.0.2
    || ==8.10.7
    || ==8.8.4
@@ -87,7 +89,7 @@ library
         Text.XML.HaXml.Schema.Schema
   hs-source-dirs: src
   build-depends:
-    base       >= 4.3.1.0  && < 4.18,
+    base       >= 4.3.1.0  && < 4.19,
     bytestring >= 0.9.1.10 && < 0.12,
     containers >= 0.4.0.0  && <0.7,
     filepath   >= 1.2.0.0  && <1.5,


### PR DESCRIPTION
This is supposed to pushed to Hackage as a revision.