### PR TITLE
HaXml 1.25.12 revision 1: bump base to <4.19

### DIFF
--- a/HaXml.cabal
+++ b/HaXml.cabal
@@ -1,6 +1,7 @@
 cabal-version:  1.18
 name:           HaXml
 version:        1.25.12
+x-revison:      1
 
 license:        LGPL-2.1
 license-files:  COPYRIGHT, LICENCE-GPL, LICENCE-LGPL
@@ -17,8 +18,9 @@ build-type:     Simple
 extra-doc-files: Changelog.md README
 
 tested-with:
-  GHC ==9.4.1
-   || ==9.2.4
+  GHC ==9.6.0
+   || ==9.4.4
+   || ==9.2.5
    || ==9.0.2
    || ==8.10.7
    || ==8.8.4
@@ -87,7 +89,7 @@ library
         Text.XML.HaXml.Schema.Schema
   hs-source-dirs: src
   build-depends:
-    base       >= 4.3.1.0  && < 4.18,
+    base       >= 4.3.1.0  && < 4.19,
     bytestring >= 0.9.1.10 && < 0.12,
     containers >= 0.4.0.0  && <0.7,
     filepath   >= 1.2.0.0  && <1.5,


### PR DESCRIPTION
This is #14 without the addition of GHC 9.6.0.20230111 to CI.