### PR TITLE
Fixes various inaccuracies in haskell generation code

### DIFF
--- a/src/Text/XML/HaXml/Namespaces.hs
+++ b/src/Text/XML/HaXml/Namespaces.hs
@@ -171,6 +171,8 @@ resolveAllNames qualify (Document prolog entities elm misc) =
               mkNamespace :: Attribute -> Namespace
               mkNamespace (N n, atv)  = let (_,':':nm) = span (/=':') n in
                                         Namespace{nsPrefix=nm,nsURI=show atv}
+              mkNamespace (q@(QN (Namespace{ nsURI="" }) n), atv)  =
+                                        Namespace{nsPrefix=n,nsURI=show atv}
               matching :: (String->Bool) -> [Attribute] -> [Attribute]
               matching p = filter (p . printableName . fst)
     --

--- a/src/Text/XML/HaXml/Parse.hs
+++ b/src/Text/XML/HaXml/Parse.hs
@@ -172,7 +172,20 @@ nottok ts = do (p,t) <- next
 -- | Return a qualified name (although the namespace qualification is not
 --   processed here; this is merely to get the correct type).
 qname :: XParser QName
-qname = fmap N name
+qname = do
+    (p,tok) <- next
+    case tok of
+        TokName s  -> case split ':' s of
+            [one] -> return $ N s
+            [ns,elem_name] -> return $ QN (Namespace ns "") elem_name
+            _ -> report fail "a name" p tok
+        TokError _ -> report failBad "a name" p tok
+        _          -> report fail "a name" p tok
+    where
+    split :: Char -> String -> [String]
+    split c xs = case break (==c) xs of
+        (ls, "") -> [ls]
+        (ls, x:rs) -> ls : split c rs
 
 -- | Return just a name, e.g. element name, attribute name.
 name :: XParser Name

--- a/src/Text/XML/HaXml/ParseLazy.hs
+++ b/src/Text/XML/HaXml/ParseLazy.hs
@@ -176,7 +176,20 @@ nottok ts = do (p,t) <- next
 -- | Return a qualified name (although the namespace qualification is not
 --   processed here; this is merely to get the correct type).
 qname :: XParser QName
-qname = fmap N name
+qname = do
+    (p,tok) <- next
+    case tok of
+        TokName s  -> case split ':' s of
+            [one] -> return $ N s
+            [ns,elem_name] -> return $ QN (Namespace ns "") elem_name
+            _ -> report fail "a name" p tok
+        TokError _ -> report failBad "a name" p tok
+        _          -> report fail "a name" p tok
+    where
+    split :: Char -> String -> [String]
+    split c xs = case break (==c) xs of
+        (ls, "") -> [ls]
+        (ls, x:rs) -> ls : split c rs
 
 -- | Return just a name, e.g. element name, attribute name.
 name :: XParser Name

--- a/src/Text/XML/HaXml/Schema/Environment.hs
+++ b/src/Text/XML/HaXml/Schema/Environment.hs
@@ -56,6 +56,7 @@ data Environment =  Environment
     , env_substGrp  :: Map QName [(QName,FilePath)] -- ^ substitution groups
     , env_typeloc   :: Map QName FilePath           -- ^ where type is defined
     }
+    deriving (Show, Eq)
 
 -- | An empty environment of XSD type mappings.
 emptyEnv :: Environment

--- a/src/Text/XML/HaXml/Schema/NameConversion.hs
+++ b/src/Text/XML/HaXml/Schema/NameConversion.hs
@@ -68,7 +68,7 @@ simpleNameConverter = NameConverter
                         | map toLower c == "integer"    = "Xsd.Integer"
                         | map toLower c == "boolean"    = "Xsd.Boolean"
                         | map toLower c == "decimal"    = "Xsd.Decimal"
-                        | otherwise = first toUpper m++"."++first toUpper (map escape c)
+                        | otherwise = first toUpper (map escape m)++"."++first toUpper (map escape c)
     mkConid more        = mkConid [concat more]
     mkVarid  [v]        = first toLower (map escape v)
     mkVarid [m,v]       = first toUpper m++"."++first toLower (map escape v)

--- a/src/Text/XML/HaXml/Schema/Parse.hs
+++ b/src/Text/XML/HaXml/Schema/Parse.hs
@@ -292,7 +292,7 @@ redefine q = do e <- xsdElement "redefine"
 simpleType :: (String->String->QName) -> XsdParser SimpleType
 simpleType q = do
     e <- xsdElement "simpleType"
-    n <- optional (attribute (N "name") name e)
+    n <- optional (attribute (N "name") string e)
     f <- optional (attribute (N "final") final e)
     a <- interiorWith (xsdTag "annotation") annotation e
     commit $ interiorWith (not . xsdTag "annotation") (simpleItem n f a) e
@@ -652,7 +652,3 @@ qname q = do a <- word
                `onFail`
                  do cs <- many next
                     return (N (a++cs))
-
--- | Parse an attribute value that should be a simple Name.
-name :: TextParser Name
-name = word

--- a/src/Text/XML/HaXml/Schema/TypeConversion.hs
+++ b/src/Text/XML/HaXml/Schema/TypeConversion.hs
@@ -398,6 +398,10 @@ convert env s = concatMap item (schema_items s)
                                                              (elem_modifier e)})
                                               es)
                                          (comment (group_annotation g))
+        Right (QN _ ref) -> case Map.lookup (N ref) (env_group env) of
+                       Nothing -> error $ "bad group reference "
+                                       ++printableName (N ref)
+                       Just g' -> group g'{ group_occurs=group_occurs g }
         Right ref -> case Map.lookup ref (env_group env) of
                   --   Nothing -> error $ "bad group reference "
                   --                      ++printableName ref

--- a/src/Text/XML/HaXml/Schema/TypeConversion.hs
+++ b/src/Text/XML/HaXml/Schema/TypeConversion.hs
@@ -27,7 +27,9 @@ typeLift s = s{ schema_items =
                     ++ map renameLocals (schema_items s) }
   where
     hoist :: ElementDecl -> [SchemaItem]
-    hoist e = flip concatMap (findE e) $
+    hoist e =
+              let only_children = filter (not . (==) e) $ findE e
+              in flip concatMap only_children $
               \e@ElementDecl{elem_nameOrRef=Left (NT{ theName=n
                                                   {-, theType=Nothing-}})}->
                   localType n (elem_content e)


### PR DESCRIPTION
This PR fixes the following (per commit):

1. If simple type contains dashes in its name like `some-thing` it will be parsed as others. For now only one-word strings are allowed like `something` or `someThing`.
2. `Environment` derivings of Show and Eq for easier debug
3. If namespace contains dashes its name will be escaped as well. For example `some-thing:type-name` will be escaped both into `Some'thing.Type'name`.
4. Fix (more like a hack, need some guidance how to make it better) for group references injecting. For now groups are injected only if they were defined in current XSD file. At origin solution all collected groups in environment have missed namespaces. This fix make a search of group name without its namespace (which can lead to wrong references if XSD locally has same name groups defined) in all collected groups of the environment.
5. Fix generated code multiple definitions of types. When top level xsd file passed into `typeLift` function its inlined elements will be generated only once. At origin implementation elements with inlined type definition lead to duplication definitions in Haskell code.