### PR TITLE
Allow bytestring-0.12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,5 +33,8 @@ jobs:
       - run: cabal update
       - run: cabal build   ${{ matrix.cabal-flags }}
       - run: cabal haddock ${{ matrix.cabal-flags }}
+        if: ${{ matrix.ghc != '8.2' }}
+          # Skip haddock step for GHC 8.2 since its haddock has problems with text-2.0.2
+          # See https://github.com/HaXml/HaXml/issues/19
       - run: cabal check
       - run: cabal sdist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ghc: ['9.4', '9.2', '9.0', '8.10', '8.8', '8.6', '8.4', '8.2', '8.0']
+        ghc: ['9.6', '9.4', '9.2', '9.0', '8.10', '8.8', '8.6', '8.4', '8.2', '8.0']
     name: Haskell GHC ${{ matrix.ghc }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,9 @@ jobs:
     strategy:
       matrix:
         ghc: ['9.6', '9.4', '9.2', '9.0', '8.10', '8.8', '8.6', '8.4', '8.2', '8.0']
+        include:
+          - ghc: '9.6'
+            cabal-flags: '--constraint=bytestring==0.12.* --allow-newer bytestring'
     name: Haskell GHC ${{ matrix.ghc }}
     steps:
       - uses: actions/checkout@v3
@@ -28,7 +31,7 @@ jobs:
             ${{ runner.os }}-${{ matrix.ghc }}-
             ${{ runner.os }}-
       - run: cabal update
-      - run: cabal build
-      - run: cabal haddock
+      - run: cabal build   ${{ matrix.cabal-flags }}
+      - run: cabal haddock ${{ matrix.cabal-flags }}
       - run: cabal check
       - run: cabal sdist

--- a/HaXml.cabal
+++ b/HaXml.cabal
@@ -90,7 +90,7 @@ library
   hs-source-dirs: src
   build-depends:
     base       >= 4.3.1.0  && < 4.19,
-    bytestring >= 0.9.1.10 && < 0.12,
+    bytestring >= 0.9.1.10 && < 0.13,
     containers >= 0.4.0.0  && <0.7,
     filepath   >= 1.2.0.0  && <1.5,
     pretty     >= 1.0.1.2  && <1.2,

--- a/HaXml.cabal
+++ b/HaXml.cabal
@@ -35,10 +35,14 @@ tested-with:
    || ==7.2.2
    || ==7.0.4
 
+source-repository head
+  type:      git
+  location:  https://github.com/HaXml/HaXml.git
+
 source-repository this
   type:      git
   location:  https://github.com/HaXml/HaXml.git
-  tag:       v1.25.6
+  tag:       v1.25.12
 
 library
   exposed-modules:

--- a/HaXml.cabal
+++ b/HaXml.cabal
@@ -18,9 +18,9 @@ build-type:     Simple
 extra-doc-files: Changelog.md README
 
 tested-with:
-  GHC ==9.6.0
-   || ==9.4.4
-   || ==9.2.5
+  GHC ==9.6.2
+   || ==9.4.5
+   || ==9.2.8
    || ==9.0.2
    || ==8.10.7
    || ==8.8.4


### PR DESCRIPTION
Allows `bytestring-0.12` and tests it in CI.

@juhp: The CI failure at https://github.com/HaXml/HaXml/actions/runs/5531720193/jobs/10092786553?pr=18 (haddock step for GHC 8.2) is unrelated to this PR and reported in:
- #19

Update: Closes #19.