### PR TITLE
Allow base-4.20 and filepath-1.5; bump CI to GHC 9.8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,14 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ghc: ['9.6', '9.4', '9.2', '9.0', '8.10', '8.8', '8.6', '8.4', '8.2', '8.0']
+        ghc: ['9.8', '9.6', '9.4', '9.2', '9.0', '8.10', '8.8', '8.6', '8.4', '8.2', '8.0']
     name: Haskell GHC ${{ matrix.ghc }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: haskell-actions/setup@v2
         with:
           ghc-version: ${{ matrix.ghc }}
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cabal

--- a/HaXml.cabal
+++ b/HaXml.cabal
@@ -1,7 +1,10 @@
 cabal-version:  1.18
 name:           HaXml
 version:        1.25.13
+x-revision:     2
+-- TODO: delete this faulty field in the next release:
 x-revison:      1
+
 
 license:        LGPL-2.1
 license-files:  COPYRIGHT, LICENCE-GPL, LICENCE-LGPL
@@ -18,8 +21,9 @@ build-type:     Simple
 extra-doc-files: Changelog.md README
 
 tested-with:
-  GHC ==9.6.3
-   || ==9.4.7
+  GHC ==9.8.2
+   || ==9.6.4
+   || ==9.4.8
    || ==9.2.8
    || ==9.0.2
    || ==8.10.7
@@ -83,10 +87,10 @@ library
         Text.XML.HaXml.Schema.Schema
   hs-source-dirs: src
   build-depends:
-    base       >= 4.3.1.0  && < 4.20,
+    base       >= 4.3.1.0  && < 4.21,
     bytestring >= 0.9.1.10 && < 0.13,
     containers >= 0.4.0.0  && <0.8,
-    filepath   >= 1.2.0.0  && <1.5,
+    filepath   >= 1.2.0.0  && <1.6,
     pretty     >= 1.0.1.2  && <1.2,
     random     >= 1.0      && <1.3,
     polyparse  >= 1.12.1   && <1.14


### PR DESCRIPTION
Note that the published cabal file has an errorneous field
`x-revison` (typo) which cannot be deleted by a revision.
Thus, we keep it around here to keep the package Hackage-revisable.

Published as hackage revision: 

2024-03-16T10:00:34Z  	AndreasAbel	  [HaXml-1.25.13-r2](https://hackage.haskell.org/package/HaXml-1.25.13/revisions)